### PR TITLE
fix clippy 'len_zero' warning

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -610,7 +610,7 @@ mod tests {
                 }
             }
 
-            if bits.len() % 32 != 0 || acked.len() == 0 {
+            if bits.len() % 32 != 0 || acked.is_empty() {
                 acked.push(tmp);
             }
 


### PR DESCRIPTION
Resolve `clippy` warning for `len_zero`.