### PR TITLE
add 'alpha' pre-release to version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utp"
-version = "0.1.0"
+version = "0.1.0-alpha"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Add `alpha` pre-release to crate version to mark instability.