### PR TITLE
feat: add 'seq' module with circular inclusive range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod congestion;
 pub mod packet;
+pub mod seq;

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,0 +1,139 @@
+/// A uTP sequence number.
+pub struct SeqNum(u16);
+
+impl SeqNum {
+    /// Returns a new sequence number with value `num`.
+    pub fn new(num: u16) -> Self {
+        Self(num)
+    }
+
+    /// Increments the sequence number by `amount` with addition modulo `u16::MAX`.
+    pub fn inc(&mut self, amount: u16) {
+        self.0 = self.0.wrapping_add(amount);
+    }
+}
+
+/// A range bounded inclusively below and above that supports wrapping arithmetic.
+///
+/// If `end < start`, then the range contains all values `x` such that `start <= x <= u16::MAX` and
+/// `0 <= x <= end`.
+#[derive(Clone, Debug)]
+pub struct CircularRangeInclusive {
+    start: u16,
+    end: u16,
+    exhausted: bool,
+}
+
+impl CircularRangeInclusive {
+    /// Returns a new range.
+    pub fn new(start: u16, end: u16) -> Self {
+        Self {
+            start,
+            end,
+            exhausted: false,
+        }
+    }
+
+    /// Returns the start of the range (inclusive).
+    pub fn start(&self) -> u16 {
+        self.start
+    }
+
+    /// Returns the end of the range (inclusive).
+    pub fn end(&self) -> u16 {
+        self.end
+    }
+
+    /// Returns `true` if `item` is contained in the range.
+    pub fn contains(&self, item: u16) -> bool {
+        if self.end >= self.start {
+            item >= self.start && item <= self.end
+        } else {
+            if item >= self.start {
+                true
+            } else {
+                item <= self.end
+            }
+        }
+    }
+}
+
+impl std::iter::Iterator for CircularRangeInclusive {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            None
+        } else {
+            if self.start == self.end {
+                self.exhausted = true;
+                Some(self.end)
+            } else {
+                let step = self.start.wrapping_add(1);
+                Some(std::mem::replace(&mut self.start, step))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use quickcheck::{quickcheck, TestResult};
+
+    #[test]
+    fn contains_start() {
+        fn prop(start: u16, end: u16) -> TestResult {
+            let range = CircularRangeInclusive::new(start, end);
+            TestResult::from_bool(range.contains(start))
+        }
+        quickcheck(prop as fn(u16, u16) -> TestResult);
+    }
+
+    #[test]
+    fn contains_end() {
+        fn prop(start: u16, end: u16) -> TestResult {
+            let range = CircularRangeInclusive::new(start, end);
+            TestResult::from_bool(range.contains(end))
+        }
+        quickcheck(prop as fn(u16, u16) -> TestResult);
+    }
+
+    #[test]
+    fn iterator() {
+        fn prop(start: u16, end: u16) -> TestResult {
+            let range = CircularRangeInclusive::new(start, end);
+
+            let mut len: usize = 0;
+            let mut expected_idx = start;
+            for idx in range {
+                assert_eq!(idx, expected_idx);
+                expected_idx = expected_idx.wrapping_add(1);
+                len += 1;
+            }
+
+            let expected_len = if start <= end {
+                usize::from(end - start) + 1
+            } else {
+                usize::from(u16::MAX - start) + usize::from(end) + 2
+            };
+            assert_eq!(len, expected_len);
+
+            TestResult::passed()
+        }
+        quickcheck(prop as fn(u16, u16) -> TestResult);
+    }
+
+    #[test]
+    fn iterator_single() {
+        fn prop(x: u16) -> TestResult {
+            let mut range = CircularRangeInclusive::new(x, x);
+            assert_eq!(range.next(), Some(x));
+            assert!(range.next().is_none());
+
+            TestResult::passed()
+        }
+        quickcheck(prop as fn(u16) -> TestResult);
+    }
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,18 +1,3 @@
-/// A uTP sequence number.
-pub struct SeqNum(u16);
-
-impl SeqNum {
-    /// Returns a new sequence number with value `num`.
-    pub fn new(num: u16) -> Self {
-        Self(num)
-    }
-
-    /// Increments the sequence number by `amount` with addition modulo `u16::MAX`.
-    pub fn inc(&mut self, amount: u16) {
-        self.0 = self.0.wrapping_add(amount);
-    }
-}
-
 /// A range bounded inclusively below and above that supports wrapping arithmetic.
 ///
 /// If `end < start`, then the range contains all values `x` such that `start <= x <= u16::MAX` and
@@ -48,12 +33,10 @@ impl CircularRangeInclusive {
     pub fn contains(&self, item: u16) -> bool {
         if self.end >= self.start {
             item >= self.start && item <= self.end
+        } else if item >= self.start {
+            true
         } else {
-            if item >= self.start {
-                true
-            } else {
-                item <= self.end
-            }
+            item <= self.end
         }
     }
 }
@@ -64,14 +47,12 @@ impl std::iter::Iterator for CircularRangeInclusive {
     fn next(&mut self) -> Option<Self::Item> {
         if self.exhausted {
             None
+        } else if self.start == self.end {
+            self.exhausted = true;
+            Some(self.end)
         } else {
-            if self.start == self.end {
-                self.exhausted = true;
-                Some(self.end)
-            } else {
-                let step = self.start.wrapping_add(1);
-                Some(std::mem::replace(&mut self.start, step))
-            }
+            let step = self.start.wrapping_add(1);
+            Some(std::mem::replace(&mut self.start, step))
         }
     }
 }


### PR DESCRIPTION
Add a `seq` module to the crate for sequence number arithmetic/utilities.

Define `CircularRangeInclusive`, an inclusive range that supports wrapping around the maximum value.

Sequence number arithmetic is modulo `u16::MAX`. The `CircularRangeInclusive` struct will be used to determine whether a given packet contains a valid sequence number.