### PR TITLE
reduce default max packet size to 2048 bytes

### DIFF
--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 const DEFAULT_TARGET_MICROS: u32 = 100_000;
 const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_MIN_TIMEOUT: Duration = Duration::from_millis(500);
-const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 65_507;
+const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 2048;
 const DEFAULT_GAIN: f32 = 1.0;
 const DEFAULT_DELAY_WINDOW: Duration = Duration::from_secs(120);
 


### PR DESCRIPTION
reduce default maximum packet size in congestion control from 65507 to 2048