### PR TITLE
refactor: change transmit method to associated function

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -402,7 +402,7 @@ impl<const N: usize> Connection<N> {
         outgoing: &mut mpsc::Sender<Packet>,
         packet: Packet,
         now: Instant,
-    ) -> bool {
+    ) {
         let payload = if packet.payload().is_empty() {
             None
         } else {
@@ -419,8 +419,6 @@ impl<const N: usize> Connection<N> {
         outgoing
             .send(packet)
             .expect("outgoing channel should be open if connection is not closed");
-
-        true
     }
 }
 


### PR DESCRIPTION
change `transmit` from method to associated function of `Connection`

* pass in all necessary fields of connection so that transmission cannot fail

other: change `lost_packets` to `retransmit_lost_packets`, calling `transmit` if there are lost packets