### PR TITLE
add trait for UDP transport abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.64"
 delay_map = "0.1.2"
 futures = "0.3.26"
 rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod seq;
 pub mod socket;
 pub mod stream;
 pub mod time;
+pub mod udp;

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,0 +1,25 @@
+use std::io;
+use std::net::SocketAddr;
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+
+/// An abstract representation of an asynchronous UDP socket.
+#[async_trait]
+pub trait AsyncUdpSocket: Send + Sync {
+    /// Attempts to send data on the socket to a given address.
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize>;
+    /// Attempts to receive a single datagram on the socket.
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)>;
+}
+
+#[async_trait]
+impl AsyncUdpSocket for UdpSocket {
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+        self.send_to(buf, *target).await
+    }
+
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.recv_from(buf).await
+    }
+}


### PR DESCRIPTION
define `AsyncUdpSocket` trait to abstract underlying transport

* add `async-trait` dependency
* implement `AsyncUdpSocket` for `tokio::net::UdpSocket`
* add `UtpSocket::with_socket` constructor that accepts `AsyncUdpSocket` implementor