### PR TITLE
add socket methods to connect/accept with given CID

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -215,7 +215,8 @@ where
         );
 
         match connected_rx.await {
-            Ok(..) => Ok(stream),
+            Ok(Ok(..)) => Ok(stream),
+            Ok(Err(err)) => Err(err),
             Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
         }
     }
@@ -224,7 +225,7 @@ where
         if self.conns.read().unwrap().contains_key(&cid) {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("connection ID in use"),
+                "connection ID in use".to_string(),
             ));
         }
 
@@ -245,7 +246,8 @@ where
         );
 
         match connected_rx.await {
-            Ok(..) => Ok(stream),
+            Ok(Ok(..)) => Ok(stream),
+            Ok(Err(err)) => Err(err),
             Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
         }
     }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use utp::cid;
 use utp::socket::UtpSocket;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -9,18 +10,30 @@ async fn socket() {
     let recv_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
     let recv = UtpSocket::bind(recv_addr).await.unwrap();
 
+    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
+    let send = UtpSocket::bind(send_addr).await.unwrap();
+
+    let recv_cid = cid::ConnectionId {
+        send: 100,
+        recv: 101,
+        peer: send_addr,
+    };
+
     let recv_handle = tokio::spawn(async move {
-        let mut stream = recv.accept().await.unwrap();
+        let mut stream = recv.accept_with_cid(recv_cid).await.unwrap();
         let mut buf = vec![];
         let n = stream.read_to_eof(&mut buf).await.unwrap();
         assert_eq!(n, data.len());
         assert_eq!(buf, data);
     });
 
-    let send_addr = SocketAddr::from(([127, 0, 0, 1], 3401));
-    let send = UtpSocket::bind(send_addr).await.unwrap();
+    let send_cid = cid::ConnectionId {
+        send: 101,
+        recv: 100,
+        peer: recv_addr,
+    };
 
-    let mut stream = send.connect(recv_addr).await.unwrap();
+    let mut stream = send.connect_with_cid(send_cid).await.unwrap();
     let n = stream.write(&data).await.unwrap();
     assert_eq!(n, data.len());
 


### PR DESCRIPTION
add methods to `UtpSocket` to connect/accept with a given `ConnectionId`

* add `connect_with_cid` method for `UtpSocket`
* add `accept_with_cid` method for `UtpSocket`
* fix non-propagated error in `connect` method of `UtpSocket`