### PR TITLE
modify CID generation fn to take endpoint flag

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -16,7 +16,7 @@ pub struct ConnectionId<P> {
 }
 
 pub trait ConnectionIdGenerator<P> {
-    fn cid(&mut self, peer: P) -> ConnectionId<P>;
+    fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P>;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -33,10 +33,14 @@ impl<P> StdConnectionIdGenerator<P> {
 }
 
 impl<P: ConnectionPeer> ConnectionIdGenerator<P> for StdConnectionIdGenerator<P> {
-    fn cid(&mut self, peer: P) -> ConnectionId<P> {
+    fn cid(&mut self, peer: P, is_initiator: bool) -> ConnectionId<P> {
         loop {
             let recv: u16 = rand::random();
-            let send = recv.wrapping_add(1);
+            let send = if is_initiator {
+                recv.wrapping_add(1)
+            } else {
+                recv.wrapping_sub(1)
+            };
             let cid = ConnectionId {
                 send,
                 recv,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -200,6 +200,10 @@ where
         utp
     }
 
+    pub fn cid(&self, peer: P, is_initiator: bool) -> ConnectionId<P> {
+        self.cid_gen.lock().unwrap().cid(peer, is_initiator)
+    }
+
     pub async fn accept(&self) -> io::Result<UtpStream<P>> {
         let (stream_tx, stream_rx) = oneshot::channel();
         self.accepts
@@ -223,7 +227,7 @@ where
     }
 
     pub async fn connect(&self, peer: P) -> io::Result<UtpStream<P>> {
-        let cid = self.cid_gen.lock().unwrap().cid(peer);
+        let cid = self.cid_gen.lock().unwrap().cid(peer, true);
         let (connected_tx, connected_rx) = oneshot::channel();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
 
@@ -251,7 +255,7 @@ where
         if self.conns.read().unwrap().contains_key(&cid) {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "connection ID in use".to_string(),
+                "connection ID unavailable".to_string(),
             ));
         }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -51,8 +51,8 @@ where
         }
     }
 
-    pub fn peer(&self) -> &P {
-        &self.cid.peer
+    pub fn cid(&self) -> &ConnectionId<P> {
+        &self.cid
     }
 
     pub async fn read_to_eof(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {


### PR DESCRIPTION
add a parameter to the `cid` function of the `ConnectionIdGenerator` trait to denote whether to generate a CID for the initiating endpoint or the accepting endpoint.