### PR TITLE
prepare crate for publish to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
-name = "utp"
+name = "utp-rs"
 version = "0.1.0-alpha"
 edition = "2021"
+authors = ["Jacob Kaufmann"]
+description = "uTorrent transport protocol"
+readme = "README.md"
+repository = "https://github.com/jacobkaufmann/utp/"
+license = "MIT"
+keywords = ["utp"]
+categories = ["network programming"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use utp::cid;
-use utp::socket::UtpSocket;
+use utp_rs::cid;
+use utp_rs::socket::UtpSocket;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn socket() {


### PR DESCRIPTION
preparations:

* change name to `utp-rs` since `utp` is unavailable
* add various metadata to `Cargo.toml`