### PR TITLE
add congestion ctrl params to conn config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utp-rs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 authors = ["Jacob Kaufmann"]
 description = "uTorrent transport protocol"

--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -2,10 +2,10 @@ use std::cmp;
 use std::collections::{BinaryHeap, HashMap};
 use std::time::{Duration, Instant};
 
-const DEFAULT_TARGET_MICROS: u32 = 100_000;
-const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(1);
-const DEFAULT_MIN_TIMEOUT: Duration = Duration::from_millis(500);
-const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 2048;
+pub(crate) const DEFAULT_TARGET_MICROS: u32 = 100_000;
+pub(crate) const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const DEFAULT_MIN_TIMEOUT: Duration = Duration::from_millis(500);
+pub(crate) const DEFAULT_MAX_PACKET_SIZE_BYTES: u32 = 1024;
 const DEFAULT_GAIN: f32 = 1.0;
 const DEFAULT_DELAY_WINDOW: Duration = Duration::from_secs(120);
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -74,15 +74,19 @@ pub struct ConnectionConfig {
     pub max_conn_attempts: usize,
     pub max_idle_timeout: Duration,
     pub initial_timeout: Duration,
+    pub min_timeout: Duration,
+    pub target_delay: Duration,
 }
 
 impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
-            max_packet_size: 1024,
             max_conn_attempts: 3,
             max_idle_timeout: Duration::from_secs(10),
-            initial_timeout: Duration::from_millis(500),
+            max_packet_size: congestion::DEFAULT_MAX_PACKET_SIZE_BYTES as u16,
+            initial_timeout: congestion::DEFAULT_INITIAL_TIMEOUT,
+            min_timeout: congestion::DEFAULT_MIN_TIMEOUT,
+            target_delay: Duration::from_micros(congestion::DEFAULT_TARGET_MICROS.into()),
         }
     }
 }
@@ -91,6 +95,9 @@ impl From<ConnectionConfig> for congestion::Config {
     fn from(value: ConnectionConfig) -> Self {
         Self {
             max_packet_size_bytes: u32::from(value.max_packet_size),
+            initial_timeout: value.initial_timeout,
+            min_timeout: value.min_timeout,
+            target_delay_micros: value.target_delay.as_micros() as u32,
             ..Default::default()
         }
     }


### PR DESCRIPTION
add the following congestion control parameters to `ConnectionConfig`:

* initial timeout
* minimum timeout
* target delay

other changes:

* change the default maximum packet size from 2048 to 1024
* expose some of the config defaults from the `congestion` module to the crate for use in the `conn` module

bump crate version from `0.1.0-alpha.1` to `0.1.0-alpha.2`