### PR TITLE
reduce log levels for various tracing events

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -166,7 +166,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
         mut reads: mpsc::UnboundedReceiver<Read>,
         mut shutdown: oneshot::Receiver<()>,
     ) {
-        tracing::info!("uTP conn starting...");
+        tracing::debug!("uTP conn starting...");
 
         // If we are the initiating endpoint, then send the SYN. If we are the accepting endpoint,
         // then send the SYN-ACK.
@@ -266,7 +266,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
                     }
                 }
                 _ = &mut shutdown, if !shutting_down => {
-                    tracing::info!("uTP conn initiating shutdown...");
+                    tracing::debug!("uTP conn initiating shutdown...");
                     shutting_down = true;
                 }
             }
@@ -276,7 +276,7 @@ impl<const N: usize, P: ConnectionPeer> Connection<N, P> {
             }
 
             if let State::Closed { err } = self.state {
-                tracing::info!(?err, "uTP conn closing...");
+                tracing::debug!(?err, "uTP conn closing...");
 
                 self.process_reads();
                 self.process_writes(Instant::now());

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -119,7 +119,7 @@ where
                                         incoming_conns.insert(cid, packet);
                                     }
                                 } else {
-                                    tracing::warn!(
+                                    tracing::debug!(
                                         cid = %packet.conn_id(),
                                         packet = ?packet.packet_type(),
                                         seq = %packet.seq_num(),
@@ -135,7 +135,7 @@ where
                             SocketEvent::Outgoing((packet, dst)) => {
                                 let encoded = packet.encode();
                                 if let Err(err) = socket.send_to(&encoded, &dst).await {
-                                    tracing::warn!(
+                                    tracing::debug!(
                                         %err,
                                         cid = %packet.conn_id(),
                                         packet = ?packet.packet_type(),
@@ -146,7 +146,7 @@ where
                                 }
                             }
                             SocketEvent::Shutdown(cid) => {
-                                tracing::info!(%cid.send, %cid.recv, "uTP conn shutdown");
+                                tracing::debug!(%cid.send, %cid.recv, "uTP conn shutdown");
                                 conns.write().unwrap().remove(&cid);
                             }
                         }


### PR DESCRIPTION
reduce log level for various `tracing` events

* `INFO` to `DEBUG`:
  * connection start
  * connection shutdown
  * connection close
* `WARN` to `DEBUG`:
  * receipt of packet for non-existing connection
  * failure to send packet over socket