### PR TITLE
bump version to 0.1.0-alpha.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utp-rs"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 authors = ["Jacob Kaufmann"]
 description = "uTorrent transport protocol"


### PR DESCRIPTION
bump version from `0.1.0-alpha.2` to `0.1.0-alpha.3`

changes:

* #40
* #41