### PR TITLE
Improve existing error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1.64"
 delay_map = "0.1.2"
 futures = "0.3.26"
 rand = "0.8.5"
+thiserror = "1.0.40"
 tokio = { version = "1.25.0", features = ["io-util", "rt-multi-thread", "macros", "net", "sync", "time"] }
 tracing = { version = "0.1.37", features = ["std", "attributes", "log"] }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -3,20 +3,44 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex, RwLock};
 
-use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, oneshot};
-
 use crate::cid::{ConnectionId, ConnectionIdGenerator, ConnectionPeer, StdConnectionIdGenerator};
+use crate::conn;
 use crate::conn::ConnectionConfig;
 use crate::event::{SocketEvent, StreamEvent};
 use crate::packet::{Packet, PacketType};
+use crate::stream;
 use crate::stream::UtpStream;
 use crate::udp::AsyncUdpSocket;
+use thiserror::Error;
+use tokio::net::UdpSocket;
+use tokio::sync::{mpsc, oneshot};
 
 type ConnChannel = mpsc::UnboundedSender<StreamEvent>;
 
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("io error, {0}")]
+    Io(#[from] io::Error),
+    #[error("uTP stream error, {0}")]
+    Stream(#[from] stream::Error),
+    #[error("no uTP stream")]
+    NoStream,
+    #[error("idle timeout, uTP connection abort")]
+    ConnectionAbort,
+    #[error("opening uTP connection failed, {0}")]
+    ConnInitError(#[from] conn::Error),
+    #[error("nonexistent connection id")]
+    NonExistentConnId,
+    #[error("notify channel failed, {0}")]
+    NotifyChannelRecv(#[from] oneshot::error::RecvError),
+    #[error("sending on accept connection channel failed")]
+    AcceptChannelSend,
+}
+
+pub struct SocketError(io::Error);
+
 struct Accept<P> {
-    stream: oneshot::Sender<io::Result<UtpStream<P>>>,
+    stream: oneshot::Sender<Result<UtpStream<P>, Error>>,
     config: ConnectionConfig,
 }
 
@@ -30,7 +54,7 @@ pub struct UtpSocket<P> {
 }
 
 impl UtpSocket<SocketAddr> {
-    pub async fn bind(addr: SocketAddr) -> io::Result<Self> {
+    pub async fn bind(addr: SocketAddr) -> Result<Self, Error> {
         let socket = UdpSocket::bind(addr).await?;
         let socket = Self::with_socket(socket);
         Ok(socket)
@@ -208,7 +232,7 @@ where
         self.cid_gen.lock().unwrap().cid(peer, is_initiator)
     }
 
-    pub async fn accept(&self, config: ConnectionConfig) -> io::Result<UtpStream<P>> {
+    pub async fn accept(&self, config: ConnectionConfig) -> Result<UtpStream<P>, Error> {
         let (stream_tx, stream_rx) = oneshot::channel();
         let accept = Accept {
             stream: stream_tx,
@@ -216,18 +240,15 @@ where
         };
         self.accepts
             .send((accept, None))
-            .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
-        match stream_rx.await {
-            Ok(stream) => Ok(stream?),
-            Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
-        }
+            .map_err(|_| Error::AcceptChannelSend)?;
+        stream_rx.await?
     }
 
     pub async fn accept_with_cid(
         &self,
         cid: ConnectionId<P>,
         config: ConnectionConfig,
-    ) -> io::Result<UtpStream<P>> {
+    ) -> Result<UtpStream<P>, Error> {
         let (stream_tx, stream_rx) = oneshot::channel();
         let accept = Accept {
             stream: stream_tx,
@@ -236,15 +257,12 @@ where
         self.accepts
             .send((accept, Some(cid)))
             .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
-        match stream_rx.await {
-            Ok(stream) => Ok(stream?),
-            Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
-        }
+        stream_rx.await?
     }
 
-    pub async fn connect(&self, peer: P, config: ConnectionConfig) -> io::Result<UtpStream<P>> {
+    pub async fn connect(&self, peer: P, config: ConnectionConfig) -> Result<UtpStream<P>, Error> {
         let cid = self.cid_gen.lock().unwrap().cid(peer, true);
-        let (connected_tx, connected_rx) = oneshot::channel();
+        let (notify_conn_open_tx, notify_conn_open_rx) = oneshot::channel();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
 
         {
@@ -257,13 +275,12 @@ where
             None,
             self.socket_events.clone(),
             events_rx,
-            connected_tx,
+            notify_conn_open_tx,
         );
 
-        match connected_rx.await {
-            Ok(Ok(..)) => Ok(stream),
-            Ok(Err(err)) => Err(err),
-            Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
+        match notify_conn_open_rx.await? {
+            Ok(..) => Ok(stream),
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -271,15 +288,12 @@ where
         &self,
         cid: ConnectionId<P>,
         config: ConnectionConfig,
-    ) -> io::Result<UtpStream<P>> {
+    ) -> Result<UtpStream<P>, Error> {
         if self.conns.read().unwrap().contains_key(&cid) {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "connection ID unavailable".to_string(),
-            ));
+            return Err(Error::NonExistentConnId);
         }
 
-        let (connected_tx, connected_rx) = oneshot::channel();
+        let (init_stream_tx, init_stream_rx) = oneshot::channel();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
 
         {
@@ -292,34 +306,25 @@ where
             None,
             self.socket_events.clone(),
             events_rx,
-            connected_tx,
+            init_stream_tx,
         );
 
-        match connected_rx.await {
-            Ok(Ok(..)) => Ok(stream),
-            Ok(Err(err)) => Err(err),
-            Err(..) => Err(io::Error::from(io::ErrorKind::TimedOut)),
+        match init_stream_rx.await? {
+            Ok(..) => Ok(stream),
+            Err(err) => Err(err.into()),
         }
     }
 
     async fn await_connected(
         stream: UtpStream<P>,
         accept: Accept<P>,
-        connected: oneshot::Receiver<io::Result<()>>,
+        connected: oneshot::Receiver<Result<(), conn::Error>>,
     ) {
-        match connected.await {
-            Ok(Ok(..)) => {
-                let _ = accept.stream.send(Ok(stream));
-            }
-            Ok(Err(err)) => {
-                let _ = accept.stream.send(Err(err));
-            }
-            Err(..) => {
-                let _ = accept
-                    .stream
-                    .send(Err(io::Error::from(io::ErrorKind::ConnectionAborted)));
-            }
-        }
+        _ = match connected.await {
+            Ok(Ok(..)) => accept.stream.send(Ok(stream)),
+            Ok(Err(err)) => accept.stream.send(Err(err.into())),
+            Err(..) => accept.stream.send(Err(Error::ConnectionAbort)),
+        };
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,5 +1,4 @@
-use std::io;
-
+use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::Instrument;
 
@@ -11,6 +10,22 @@ use crate::packet::Packet;
 /// The size of the send and receive buffers.
 // TODO: Make the buffer size configurable.
 const BUF: usize = 1024 * 1024;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("uTP connection error, {0}")]
+    Conn(#[from] conn::Error),
+    #[error("no uTP connection")]
+    NoConn,
+    #[error("sending on notify channel failed")]
+    NotifyShutdown,
+    #[error("notify channel failed, {0}")]
+    NotifyChannelRecv(#[from] oneshot::error::RecvError),
+    #[error("sending on read channel failed")]
+    ReadChannelSend,
+    #[error("sending on write channel failed")]
+    WriteChannelSend,
+}
 
 pub struct UtpStream<P> {
     cid: ConnectionId<P>,
@@ -29,10 +44,15 @@ where
         syn: Option<Packet>,
         socket_events: mpsc::UnboundedSender<SocketEvent<P>>,
         stream_events: mpsc::UnboundedReceiver<StreamEvent>,
-        connected: oneshot::Sender<io::Result<()>>,
+        notify_conn_open: oneshot::Sender<Result<(), conn::Error>>,
     ) -> Self {
-        let mut conn =
-            conn::Connection::<BUF, P>::new(cid.clone(), config, syn, connected, socket_events);
+        let mut conn = conn::Connection::<BUF, P>::new(
+            cid.clone(),
+            config,
+            syn,
+            notify_conn_open,
+            socket_events,
+        );
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (reads_tx, reads_rx) = mpsc::unbounded_channel();
@@ -55,7 +75,7 @@ where
         &self.cid
     }
 
-    pub async fn read_to_eof(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+    pub async fn read_to_eof(&mut self, buf: &mut Vec<u8>) -> Result<usize, Error> {
         // Reserve space in the buffer to avoid expensive allocation for small reads.
         buf.reserve(2048);
 
@@ -64,52 +84,40 @@ where
             let (tx, rx) = oneshot::channel();
             self.reads
                 .send((buf.capacity(), tx))
-                .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
+                .map_err(|_| Error::ReadChannelSend)?;
 
-            match rx.await {
-                Ok(result) => match result {
-                    Ok(mut data) => {
-                        if data.is_empty() {
-                            break Ok(n);
-                        }
-                        n += data.len();
-                        buf.append(&mut data);
-
-                        // Reserve additional space in the buffer proportional to the amount of
-                        // data read.
-                        buf.reserve(data.len());
-                    }
-                    Err(err) => return Err(err),
-                },
-                Err(err) => return Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
+            let mut data = rx.await??;
+            if data.is_empty() {
+                break Ok(n);
             }
+            n += data.len();
+            buf.append(&mut data);
+
+            // Reserve additional space in the buffer proportional to the amount of
+            // data read.
+            buf.reserve(data.len());
         }
     }
 
-    pub async fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    pub async fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         if self.shutdown.is_none() {
-            return Err(io::Error::from(io::ErrorKind::NotConnected));
+            return Err(Error::NoConn);
         }
 
         let (tx, rx) = oneshot::channel();
         self.writes
             .send((buf.to_vec(), tx))
-            .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?;
+            .map_err(|_| Error::WriteChannelSend)?;
 
-        match rx.await {
-            Ok(n) => Ok(n?),
-            Err(err) => Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}"))),
-        }
+        Ok(rx.await??)
     }
 }
 
 impl<P> UtpStream<P> {
-    pub fn shutdown(&mut self) -> io::Result<()> {
+    pub fn shutdown(&mut self) -> Result<(), Error> {
         match self.shutdown.take() {
-            Some(shutdown) => Ok(shutdown
-                .send(())
-                .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))?),
-            None => Err(io::Error::from(io::ErrorKind::NotConnected)),
+            Some(shutdown) => Ok(shutdown.send(()).map_err(|_| Error::NotifyShutdown)?),
+            None => Err(Error::NoConn),
         }
     }
 }
@@ -117,5 +125,37 @@ impl<P> UtpStream<P> {
 impl<P> Drop for UtpStream<P> {
     fn drop(&mut self) {
         let _ = self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::conn::ConnectionConfig;
+    use crate::socket::UtpSocket;
+    use std::net::SocketAddr;
+    #[tokio::test]
+    async fn test_transfer_100k_bytes() {
+        // set-up test
+        let sender_addr = SocketAddr::from(([127, 0, 0, 1], 3400));
+        let receiver_address = SocketAddr::from(([127, 0, 0, 1], 3401));
+        let config = ConnectionConfig::default();
+        let sender = UtpSocket::bind(sender_addr).await.unwrap();
+        let receiver = UtpSocket::bind(receiver_address).await.unwrap();
+        let mut tx_stream = sender.connect(receiver_address, config).await.unwrap();
+        let mut rx_stream = receiver.accept(config).await.unwrap();
+
+        // write 100k bytes data to the remote peer over the stream.
+        let data = vec![0xef; 100_000];
+        tx_stream
+            .write(data.as_slice())
+            .await
+            .expect("Should send 100k bytes");
+
+        // read data from the remote peer until the peer indicates there is no data left to write.
+        let mut data = vec![];
+        rx_stream
+            .read_to_eof(&mut data)
+            .await
+            .expect("Should receive 100k bytes");
     }
 }


### PR DESCRIPTION
Propagates existing errors from where they are created to the call that triggered them to allow for easy debugging.

Included Nick's test in this issue https://github.com/jacobkaufmann/utp/issues/44 as a test in stream.rs 